### PR TITLE
bug fix: end function use Promise class from Sequelizejs that had bee…

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -8,7 +8,6 @@
 var _        = require('lodash'),
 	contract = require('./contract'),
 	dbTasks  = require('./dbTasks'),
-	Promise  = require('bluebird'),
 	defaults = {
 		prefix : ''
 	};
@@ -118,7 +117,7 @@ SequelizeBackend.prototype = {
 		contract(arguments).params('object', 'function').end();
 		// Execute transaction
 		var i =1 ;
-		return Promise.reduce(transaction, function (res, func) {
+		return this.db.Promise.reduce(transaction, function (res, func) {
 			var n = i++;
 			return func().then(function () {
 			});

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   },
   "homepage": "https://github.com/yonjah/node_acl_sequelize",
   "dependencies": {
-    "bluebird": "^2.9.24",
     "lodash": "^3.2.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
bug fix: end function use Promise class from Sequelizejs that had been bind namespace.

We should use the Promise class the carry in with the db options. we shoud not import new Promise.
The Promise the come with sequelize db instance is shimmed by sequelize(in lib/Promise.js) and bind the namespace. so can support database transaction.
